### PR TITLE
Fix imported Voronoi being offset from selected profile

### DIFF
--- a/Voronoi.py
+++ b/Voronoi.py
@@ -187,6 +187,30 @@ def getProfilePoints(profile):
     return sortedProfileCurves
 
 
+# Compute the bbox of the sampled profile points (matches what the JS editor sees).
+# Returns (minPoint, width, height) in cm, or None if no points.
+# We use this instead of profile.boundingBox because the API bbox can include extents
+# that the sampled-point polyline doesn't actually reach (e.g. for arc/spline profile
+# segments whose underlying geometry has different parameter extents than the trimmed
+# segment), which causes the imported SVG to be offset relative to the cells.
+def getProfilePointsBounds(profilePoints):
+    if not profilePoints:
+        return None
+    xmin = ymin = float('inf')
+    xmax = ymax = float('-inf')
+    hasPoints = False
+    for path in profilePoints:
+        for pt in path:
+            hasPoints = True
+            if pt.x < xmin: xmin = pt.x
+            if pt.y < ymin: ymin = pt.y
+            if pt.x > xmax: xmax = pt.x
+            if pt.y > ymax: ymax = pt.y
+    if not hasPoints:
+        return None
+    return (adsk.core.Point3D.create(xmin, ymin, 0), xmax - xmin, ymax - ymin)
+
+
 def getProfileBounds(profile):
 
     outerLoop = None
@@ -307,17 +331,23 @@ class VoronoiCommandInputChangedHandler(adsk.core.InputChangedEventHandler):
 
                 # If a profile selected, then get dimensions and set in inputs
                 if profile != None:
-                    # Get profile width/height (in centimeters)
-                    widthProfile = bboxProfile.maxPoint.x - bboxProfile.minPoint.x
-                    heightProfile = bboxProfile.maxPoint.y - bboxProfile.minPoint.y
+                    _profilePoints = getProfilePoints(profile)
+                    _profileSketchName = profileSketchName
+
+                    # Use the bbox of the actual sampled points (what the JS editor uses)
+                    # rather than profile.boundingBox, so that placement on import aligns
+                    # with what the user sees in the editor preview.
+                    pointsBounds = getProfilePointsBounds(_profilePoints)
+                    if pointsBounds is not None:
+                        _profileOrigin, widthProfile, heightProfile = pointsBounds
+                    else:
+                        widthProfile = bboxProfile.maxPoint.x - bboxProfile.minPoint.x
+                        heightProfile = bboxProfile.maxPoint.y - bboxProfile.minPoint.y
+                        _profileOrigin = bboxProfile.minPoint
 
                     # Set the profile width and height input values
                     _widthProfileStringValueCommandInput.value = '{0:.2f} '.format(des.unitsManager.convert(widthProfile, 'cm', _units)) + _units
                     _heightProfileStringValueCommandInput.value = '{0:.2f} '.format(des.unitsManager.convert(heightProfile, 'cm', _units)) + _units
-
-                    _profilePoints = getProfilePoints(profile)
-                    _profileSketchName = profileSketchName
-                    _profileOrigin = bboxProfile.minPoint
                 else:
                     _widthProfileStringValueCommandInput.value = "0.0"
                     _heightProfileStringValueCommandInput.value = "0.0"
@@ -335,8 +365,14 @@ class VoronoiCommandInputChangedHandler(adsk.core.InputChangedEventHandler):
                 # Copy profile size over to voronoi size (should only be possible if profile selected)
                 ( profile, bboxProfile, profileSketchName) = getSelectedProfile()
                 if profile != None:
-                    _widthValueCommandInput.value = bboxProfile.maxPoint.x - bboxProfile.minPoint.x
-                    _heightValueCommandInput.value = bboxProfile.maxPoint.y - bboxProfile.minPoint.y
+                    pointsBounds = getProfilePointsBounds(_profilePoints)
+                    if pointsBounds is not None:
+                        _, w, h = pointsBounds
+                        _widthValueCommandInput.value = w
+                        _heightValueCommandInput.value = h
+                    else:
+                        _widthValueCommandInput.value = bboxProfile.maxPoint.x - bboxProfile.minPoint.x
+                        _heightValueCommandInput.value = bboxProfile.maxPoint.y - bboxProfile.minPoint.y
                 else:
                     _widthValueCommandInput.value = 0
                     _heightValueCommandInput.value = 0
@@ -644,7 +680,7 @@ class CreateVoronoiCommandExecuteHandler(adsk.core.CommandEventHandler):
             #print("Profile XY Orig = {0},{1}".format(xPos, yPos))
         else:
             yPos = _heightVoronoi
-        
+
         # import the temp svg file into the sketch.
         retValue = theSketch.importSVG(_svgFilePath, xPos, yPos, 1)    # (filePath, xPos, yPos, scale)
 


### PR DESCRIPTION
## Summary

When a sketch profile is used as the Voronoi shape, the imported SVG lands offset from the profile. The offset is most visible with curved profiles (e.g. ~14% Y offset for a circle); square profiles align correctly.

**Root cause:** Python derived the import position and the *Use Profile Size* dimensions from `profile.boundingBox`, while the JS editor sized the SVG from the bbox of the sampled-point polyline sent over JSON. For profiles containing arcs/splines, the API bbox can extend beyond what `getProfilePoints()` actually samples — e.g. an arc whose underlying geometry's parameter extents differ from the trimmed segment — so the two bboxes disagreed, and the offset visible in Fusion was their delta. Square profiles are pure lines whose endpoints define the bbox exactly, so they matched and showed no offset.

**Fix:** introduce `getProfilePointsBounds()` and use the sampled-point bbox for `_profileOrigin` / width / height in both the selection-changed and *Use Profile Size* handlers, so Python and the JS editor agree on what the profile range is. Falls back to `profile.boundingBox` when no points are available. JS side unchanged.

## Test plan

- [x] Square profile — still aligns (regression check)
- [x] Circle profile — now aligns (was offset on both axes before)
- [x] Circle-with-bump profile — now aligns (was ~14% Y offset before)
- [x] No profile selected (sketch-only / construction-plane path) — unchanged