### PR TITLE
Use equal padding from all sides of profile. Use document units in generator.

### DIFF
--- a/Voronoi.html
+++ b/Voronoi.html
@@ -79,7 +79,7 @@
                             </div>
                             <span class="font-weight-bold text-primary ml-2" id="cellGapValueSpan" style="display: inline-block; width: 2em;"></span>
                         </div>
-                        <small id="cellGapHelp" class="form-text text-muted">Gap between cells (mm)</small>
+                        <small id="cellGapHelp" class="form-text text-muted">Gap between cells <span class="units"></span></small>
                     </div>
 
                     <div class="form-group">

--- a/Voronoi.py
+++ b/Voronoi.py
@@ -506,13 +506,15 @@ class VoronoiCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
             _constructionPlaneDropDownInput.listItems.add(_CONSTRUCTION_PLANE_XZ, (_constructionPlane == _CONSTRUCTION_PLANE_XZ))
             _constructionPlaneDropDownInput.listItems.add(_CONSTRUCTION_PLANE_YZ, (_constructionPlane == _CONSTRUCTION_PLANE_YZ))
 
-            # Create a default values using a string
-            value_width = adsk.core.ValueInput.createByString('6.0 in')
-            value_height = adsk.core.ValueInput.createByString('4.0 in')
-
-            if _units != 'in' and _units != 'ft':
-                value_width = adsk.core.ValueInput.createByString('15.0 cm')
-                value_height = adsk.core.ValueInput.createByString('10.0 cm')
+            # Create default values in document units
+            _default_sizes = {
+                'in': ('6.0 in',   '4.0 in'),
+                'ft': ('0.5 ft',   '0.333 ft'),
+                'mm': ('150.0 mm', '100.0 mm'),
+            }
+            _w_str, _h_str = _default_sizes.get(_units, ('15.0 cm', '10.0 cm'))
+            value_width  = adsk.core.ValueInput.createByString(_w_str)
+            value_height = adsk.core.ValueInput.createByString(_h_str)
 
             _widthValueCommandInput = cmdInputs_.addValueInput(_VALUE_INPUT_ID_WIDTH, 'Width', _units, value_width) # adsk.core.ValueInput.createByReal(25.0))
             _heightValueCommandInput = cmdInputs_.addValueInput(_VALUE_INPUT_ID_HEIGHT, 'Height', _units, value_height) # adsk.core.ValueInput.createByReal(20.0))

--- a/Voronoi.py
+++ b/Voronoi.py
@@ -4,8 +4,9 @@
 #MIT License: See https://github.com/hanskellner/Fusion360Voronoi/LICENSE.md
 
 import adsk.core, adsk.fusion, adsk.cam, traceback
-import json, tempfile, platform
+import json, tempfile
 from urllib.parse import unquote
+import os
 
 #############################################################################
 # global constants
@@ -114,7 +115,7 @@ def getProfilePoints(profile):
             outerLoop = profile.profileLoops.item(iLoop)
             break
 
-    if outerLoop == None:
+    if outerLoop is None:
         return None
 
     profileCurves = []  # Will contain an array for each curve
@@ -135,8 +136,8 @@ def getProfilePoints(profile):
             (retVal, startParam, endParam) = evaluator.getParameterExtents()
             (retVal, length) = evaluator.getLengthAtParameter(startParam, endParam)
 
-            num_steps = length / 0.2   # step every 2mm
-            step = (endParam - startParam)/num_steps
+            num_steps = max(1, length / 0.2)   # step every 2mm
+            step = (endParam - startParam) / num_steps
 
             param = startParam
             while param < endParam:
@@ -157,7 +158,7 @@ def getProfilePoints(profile):
 
     # Extract each profile curve as it gets added to sorted list
     while len(profileCurves) > 0:
-        if lastCurve == None:
+        if lastCurve is None:
             lastCurve = profileCurves[0]
             sortedProfileCurves.append(lastCurve)
             profileCurves.pop(0)
@@ -189,7 +190,7 @@ def getProfilePoints(profile):
                     break   # Drop out of for loop
 
             # If not match found then we need to exit search but first copy over path as-is
-            if foundMatch == False:
+            if not foundMatch:
                 print("Unable to sort profile paths")
                 for iCurve in range(len(profileCurves)):
                     sortedProfileCurves.append(profileCurves[iCurve])
@@ -232,7 +233,7 @@ def getProfileBounds(profile):
             outerLoop = profile.profileLoops.item(iLoop)
             break
 
-    if outerLoop == None:
+    if outerLoop is None:
         return None
     else:
         return profile.boundingBox # Return the BBOX for the profile since it's got an outer loop
@@ -277,7 +278,7 @@ def setFixedSketchPoints(sketchCurves, flag):
         for iCurve in range(sketchCurves.count):
             curve = sketchCurves.item(iCurve)
             curve.isFixed = flag
-    except:
+    except Exception:
         if _ui:
             _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
 
@@ -289,32 +290,12 @@ def sendInitInfoToHTML(palette):
 
     global _units, _widthVoronoi, _heightVoronoi, _profilePoints
 
-    #des = adsk.fusion.Design.cast(_app.activeProduct)
-
-    jsonDataStr = '{{"units": "{0}", "width": "{1}", "height": "{2}", "profile": ['.format(_units, _widthVoronoi, _heightVoronoi)
-
-    # If profile selected and there are profile points then add to json
-    for iPath in range(len(_profilePoints)):
-        if iPath > 0:
-            jsonDataStr += ', '
-        jsonDataStr += '['
-
-        pathPoints = _profilePoints[iPath]
-        for iPt in range(len(pathPoints)):
-            if iPt > 0:
-                jsonDataStr += ', '
-
-            x = pathPoints[iPt].x # des.unitsManager.convert(pathPoints[iPt].x, 'cm', _units)
-            y = pathPoints[iPt].y # des.unitsManager.convert(pathPoints[iPt].y, 'cm', _units)
-            
-            jsonDataStr += '{{"x":"{0:.4}","y":"{1:.4}"}}'.format(x,y)
-
-        jsonDataStr += ']'
-
-    jsonDataStr += ']}'
-    print(jsonDataStr)
-
-    palette.sendInfoToHTML('init', jsonDataStr)
+    profile_data = [
+        [{"x": f"{pt.x:.4f}", "y": f"{pt.y:.4f}"} for pt in path]
+        for path in _profilePoints
+    ]
+    payload = {"units": _units, "width": str(_widthVoronoi), "height": str(_heightVoronoi), "profile": profile_data}
+    palette.sendInfoToHTML('init', json.dumps(payload))
 
 
 #############################################################################
@@ -338,10 +319,10 @@ class VoronoiCommandInputChangedHandler(adsk.core.InputChangedEventHandler):
                 _selectedSketchName = getSelectedSketchName()
                 ( profile, bboxProfile, profileSketchName) = getSelectedProfile()
 
-                _constructionPlaneDropDownInput.isEnabled = (profile == None and _selectedSketchName == '')
+                _constructionPlaneDropDownInput.isEnabled = (profile is None and _selectedSketchName == '')
 
                 # If a profile selected, then get dimensions and set in inputs
-                if profile != None:
+                if profile is not None:
                     _profilePoints = getProfilePoints(profile)
                     _profileSketchName = profileSketchName
                     _profileSketch = profile.parentSketch
@@ -371,9 +352,9 @@ class VoronoiCommandInputChangedHandler(adsk.core.InputChangedEventHandler):
                     _profileWidth = 0
                     _profileHeight = 0
 
-                _widthProfileStringValueCommandInput.isVisible = (profile != None)
-                _heightProfileStringValueCommandInput.isVisible = (profile != None)
-                _applyProfileSizeBoolValueInput.isVisible = (profile != None)
+                _widthProfileStringValueCommandInput.isVisible = (profile is not None)
+                _heightProfileStringValueCommandInput.isVisible = (profile is not None)
+                _applyProfileSizeBoolValueInput.isVisible = (profile is not None)
 
             elif changedInput.id == _DROPDOWN_INPUT_ID_CONSTRUCTION_PLANE:
                 _constructionPlane = _constructionPlaneDropDownInput.selectedItem.name
@@ -381,7 +362,7 @@ class VoronoiCommandInputChangedHandler(adsk.core.InputChangedEventHandler):
             elif changedInput.id == _BOOL_INPUT_ID_APPLY_PROFILE_SIZE:
                 # Copy profile size over to voronoi size (should only be possible if profile selected)
                 ( profile, bboxProfile, profileSketchName) = getSelectedProfile()
-                if profile != None:
+                if profile is not None:
                     pointsBounds = getProfilePointsBounds(_profilePoints)
                     if pointsBounds is not None:
                         _, w, h = pointsBounds
@@ -400,7 +381,7 @@ class VoronoiCommandInputChangedHandler(adsk.core.InputChangedEventHandler):
             if _heightValueCommandInput.isValidExpression:
                 _heightVoronoi = _heightValueCommandInput.value
 
-        except:
+        except Exception:
             if _ui:
                 _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
         
@@ -418,7 +399,7 @@ class VoronoiCommandActivatedHandler(adsk.core.CommandEventHandler):
             _heightProfileStringValueCommandInput.isVisible = False
             _applyProfileSizeBoolValueInput.isVisible = False
 
-        except:
+        except Exception:
             if _ui:
                 _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
 
@@ -461,7 +442,7 @@ class VoronoiCommandExecuteHandler(adsk.core.CommandEventHandler):
                 # received by the browser that first time.  Handled in a html callback.
                 sendInitInfoToHTML(palette)
 
-        except:
+        except Exception:
             if _ui:
                 _ui.messageBox('Command executed failed: {}'.format(traceback.format_exc()))
 
@@ -483,6 +464,7 @@ class VoronoiCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
             _units = des.unitsManager.defaultLengthUnits
 
             # No profile
+            global _profileSketchName
             _profileSketchName = ''
 
             # Setup the command
@@ -549,7 +531,7 @@ class VoronoiCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
             onActivate = VoronoiCommandActivatedHandler()
             cmd.activate.add(onActivate)
             _handlers.append(onActivate)
-        except:
+        except Exception:
             _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
 
 
@@ -561,7 +543,7 @@ class PaletteCloseEventHandler(adsk.core.UserInterfaceGeneralEventHandler):
         try:
             #_ui.messageBox('Close button was clicked.')
             pass
-        except:
+        except Exception:
             if _ui:
                 _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
 
@@ -618,7 +600,7 @@ class MyHTMLEventHandler(adsk.core.HTMLEventHandler):
 
                     # Save the SVG to a temp file            
                     fp = tempfile.NamedTemporaryFile(mode='w', suffix='.svg', delete=False)
-                    fp.writelines(svgStr)
+                    fp.write(svgStr)
                     fp.close()
                     _svgFilePath = fp.name
                     print ("Generated temporary SVG file: " + _svgFilePath)
@@ -626,13 +608,14 @@ class MyHTMLEventHandler(adsk.core.HTMLEventHandler):
                     # Get the command definition for the create voronoi core command which
                     # will do the work.
                     createVoronoiCoreCmdDef = _ui.commandDefinitions.itemById(_CREATE_VORONOI_CORE_CMD_ID)
-                    if createVoronoiCoreCmdDef != None:
+                    if createVoronoiCoreCmdDef is not None:
                         namedValues = adsk.core.NamedValues.create()
                         namedValues.add('svgFilePath', adsk.core.ValueInput.createByString(_svgFilePath))
                         createVoronoiCoreCmdDef.execute(namedValues)
                     else:
-                        pass    # error!
-        except:
+                        if _ui:
+                            _ui.messageBox('Failed to find the CreateVoronoi command definition.')
+        except Exception:
             if _ui:
                 _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
 
@@ -676,7 +659,7 @@ class CreateVoronoiCommandExecuteHandler(adsk.core.CommandEventHandler):
         elif _profileSketch is not None:
             theSketch = _profileSketch
         
-        if theSketch == None:
+        if theSketch is None:
             # Which plane if no sketch?
             # xYConstructionPlane, xZConstructionPlane, yZConstructionPlane
             plane = rootComp.xYConstructionPlane
@@ -693,7 +676,7 @@ class CreateVoronoiCommandExecuteHandler(adsk.core.CommandEventHandler):
         xPos = 0
         yPos = 0
 
-        if _profileSketchName != '' and _profileOrigin != None:
+        if _profileSketchName != '' and _profileOrigin is not None:
             xPos = _profileOrigin.x
             # When inserting into a selected profile, align to the profile's sampled
             # bounds (the same bounds used by the editor preview), not the dialog size.
@@ -705,8 +688,13 @@ class CreateVoronoiCommandExecuteHandler(adsk.core.CommandEventHandler):
         # import the temp svg file into the sketch.
         retValue = theSketch.importSVG(_svgFilePath, xPos, yPos, 1)    # (filePath, xPos, yPos, scale)
 
+        try:
+            os.unlink(_svgFilePath)
+        except OSError:
+            pass
+        
         # Check if the import was successful
-        if retValue == False:
+        if not retValue:
             if _ui:
                 _ui.messageBox('Failed to import the Voronoi.  Unable to continue.')
         else:
@@ -757,7 +745,7 @@ def run(context):
         
         if context['IsApplicationStartup'] is False:
             _ui.messageBox('The "Voronoi Sketch Generator" command has been added\nto the SOLID->CREATE panel dropdown of the DESIGN workspace.\n\nTo run the command, select the SOLID->CREATE dropdown\nthen select "Voronoi Sketch Generator".')
-    except:
+    except Exception:
         #pass
         if _ui:
             _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
@@ -784,6 +772,7 @@ def stop(context):
         cmdDef = _ui.commandDefinitions.itemById(_CREATE_VORONOI_CORE_CMD_ID)
         if cmdDef:
             cmdDef.deleteMe()
-    except:
+        _handlers.clear()
+    except Exception:
         if _ui:
             _ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))

--- a/js/voronoi-editor.js
+++ b/js/voronoi-editor.js
@@ -589,6 +589,91 @@ $(function() {
         path.scale(newScale);
     }
 
+    // Inset a polygon path inward by a fixed distance uniformly on all sides.
+    // Unlike scaleCellToDistance (which scales from the centroid and produces
+    // proportionally unequal insets on non-square shapes), this offsets each edge
+    // perpendicularly by the exact distance and intersects adjacent offset edges to
+    // find the new vertex positions.  Used for the profile gap path.
+    function insetPathByDistance(path, distance) {
+        if (distance <= 0) return;
+        var segCount = path.segments.length;
+        if (segCount < 3) return;
+
+        var pts = [];
+        for (var i = 0; i < segCount; i++) {
+            pts.push(path.segments[i].point.clone());
+        }
+
+        // The profile path is built as quasi-closed: each segment's end point is the
+        // next segment's start, so the final point duplicates the first.  Detect this
+        // and work with only the n unique corner vertices so no zero-length edge skips
+        // a corner during the inset calculation.
+        var lastDupsFirst = segCount > 3 &&
+            Math.abs(pts[segCount-1].x - pts[0].x) < 1e-6 &&
+            Math.abs(pts[segCount-1].y - pts[0].y) < 1e-6;
+
+        var n = lastDupsFirst ? segCount - 1 : segCount;
+        if (n < 3) return;
+
+        // Determine winding via the shoelace signed-area formula.
+        // Positive result = CW in screen space (Y increases downward).
+        var area = 0;
+        for (var i = 0; i < n; i++) {
+            var j = (i + 1) % n;
+            area += pts[i].x * pts[j].y - pts[j].x * pts[i].y;
+        }
+        var cw = area > 0;
+
+        var newPts = [];
+        for (var i = 0; i < n; i++) {
+            var prev = pts[(i - 1 + n) % n];
+            var curr = pts[i];
+            var next = pts[(i + 1) % n];
+
+            // Unit vectors of incoming edge (prev→curr) and outgoing edge (curr→next)
+            var ax = curr.x - prev.x, ay = curr.y - prev.y;
+            var bx = next.x - curr.x, by = next.y - curr.y;
+            var la = Math.sqrt(ax*ax + ay*ay), lb = Math.sqrt(bx*bx + by*by);
+            if (la < 1e-10 || lb < 1e-10) { newPts.push(curr.clone()); continue; }
+            ax /= la; ay /= la;
+            bx /= lb; by /= lb;
+
+            // Inward unit normals:
+            //   CW winding  → left normal  = (-ey, ex)
+            //   CCW winding → right normal = ( ey,-ex)
+            var na_x = cw ? -ay : ay,  na_y = cw ?  ax : -ax;
+            var nb_x = cw ? -by : by,  nb_y = cw ?  bx : -bx;
+
+            // Two offset lines that meet at the inset corner:
+            //   Line A: (prev + na*d) → (curr + na*d)
+            //   Line B: (curr + nb*d) → (next + nb*d)
+            var p1x = prev.x + na_x*distance, p1y = prev.y + na_y*distance;
+            var p2x = curr.x + na_x*distance, p2y = curr.y + na_y*distance;
+            var p3x = curr.x + nb_x*distance, p3y = curr.y + nb_y*distance;
+            var p4x = next.x + nb_x*distance, p4y = next.y + nb_y*distance;
+
+            var dx1 = p2x-p1x, dy1 = p2y-p1y;
+            var dx2 = p4x-p3x, dy2 = p4y-p3y;
+            var cross = dx1*dy2 - dy1*dx2;
+
+            if (Math.abs(cross) < 1e-10) {
+                // Parallel edges (e.g. straight corner) — use the offset point directly
+                newPts.push(new paper.Point(p2x, p2y));
+            } else {
+                var t = ((p3x-p1x)*dy2 - (p3y-p1y)*dx2) / cross;
+                newPts.push(new paper.Point(p1x + t*dx1, p1y + t*dy1));
+            }
+        }
+
+        for (var i = 0; i < n; i++) {
+            path.segments[i].point = newPts[i];
+        }
+        // Keep the quasi-closed duplicate last point in sync with the (now inset) first point
+        if (lastDupsFirst) {
+            path.segments[segCount - 1].point = newPts[0].clone();
+        }
+    }
+
     function cellSitesCount() {
         return _cellSitesRelaxed.length;
     }
@@ -689,7 +774,7 @@ $(function() {
                 _profilePathGap = _profilePath.clone(); //{ insert: true, deep: true });
                 _profilePathGap.strokeColor = 'purple';
 
-                scaleCellToDistance(_profilePathGap, cms2pixels(propertyPagePadding()));
+                insetPathByDistance(_profilePathGap, cms2pixels(propertyPagePadding()));
             }
         }
         else {

--- a/js/voronoi-editor.js
+++ b/js/voronoi-editor.js
@@ -38,6 +38,8 @@ $(function() {
     // Fusion 360 API.  THerefore, that's what is used here.
     var UNITS = {
         Inches: 'in',
+        Feet: 'ft',
+        Millimeters: 'mm',
         Centimeters: 'cm'
     }
 
@@ -87,6 +89,10 @@ $(function() {
     
     function inches2cms(val) { return (val * 2.54); }
     function cms2inches(val) { return (val / 2.54); }
+    function mm2cms(val) { return val / 10.0; }
+    function cms2mm(val) { return val * 10.0; }
+    function ft2cms(val) { return val * 30.48; }
+    function cms2ft(val) { return val / 30.48; }
 
     $('#sidebarCollapse').on('click', function () {
         $('#sidebar').toggleClass('active');
@@ -154,7 +160,13 @@ $(function() {
 
     function propertyCellGap(defaultGap = 0.1) {
         var gap = parseFloat($valueCellGap.val());
-        return (gap !== NaN) ? gap / 10.0 : defaultGap;
+        if (isNaN(gap)) return defaultGap;
+        switch (_units) {
+            case 'in': return inches2cms(gap);
+            case 'ft': return ft2cms(gap);
+            case 'mm': return mm2cms(gap);
+            default:   return gap; // cm
+        }
     }
 
     // For the cell shape scale range
@@ -260,12 +272,16 @@ $(function() {
     // Return the page padding (in CMs).
     function propertyPagePadding() {
         var val = Number($valuePagePadding.val());
-        if (val === NaN || val < 0) {
+        if (isNaN(val) || val < 0) {
             return _padding; // Incoming is invalid so use current value
         }
         else {
-            // REVIEW: Set the local var _padding too?
-            return (propertyUnits() === UNITS.Inches) ? inches2cms(val) : val;  // Need to convert to cms internally
+            switch (_units) {
+                case 'in': return inches2cms(val);
+                case 'ft': return ft2cms(val);
+                case 'mm': return mm2cms(val);
+                default:   return val; // cm
+            }
         }
     }
 
@@ -274,8 +290,14 @@ $(function() {
         _padding = val; // TODO: Validate
 
         // Form display value in selected units
-        let formVal = (propertyUnits() === UNITS.Inches) ? cms2inches(val) : val;
-        $valuePagePadding.val(Number(formVal.toFixed(2)));
+        let formVal;
+        switch (_units) {
+            case 'in': formVal = cms2inches(val); break;
+            case 'ft': formVal = cms2ft(val); break;
+            case 'mm': formVal = cms2mm(val); break;
+            default:   formVal = val; break; // cm
+        }
+        $valuePagePadding.val(Number(formVal.toFixed(3)));
     }
 
     // Number of iterations for Lloyd's Relaxation
@@ -324,8 +346,32 @@ $(function() {
     // Units indicator
     const $valueUnitsIndicator = $('.units');
     function updatePropertyUnitsIndicator() {
-        let formVal = (propertyUnits() === UNITS.Inches) ? '(inches)' : '(cm)';
+        let formVal;
+        switch (_units) {
+            case 'in': formVal = '(inches)'; break;
+            case 'ft': formVal = '(feet)'; break;
+            case 'mm': formVal = '(mm)'; break;
+            default:   formVal = '(cm)'; break;
+        }
         $valueUnitsIndicator.text(formVal);
+    }
+
+    // Update cell gap slider range and default value to match current units
+    function updateCellGapForUnits() {
+        var config;
+        switch (_units) {
+            case 'in': config = {max: '0.8',  step: '0.005', defaultVal: '0.04'}; break;
+            case 'ft': config = {max: '0.07', step: '0.001', defaultVal: '0.003'}; break;
+            case 'mm': config = {max: '20',   step: '0.1',   defaultVal: '1'};    break;
+            default:   config = {max: '2',    step: '0.01',  defaultVal: '0.1'};  break; // cm
+        }
+        $valueCellGap.attr({max: config.max, step: config.step});
+        var curVal = parseFloat($valueCellGap.val());
+        var maxVal = parseFloat(config.max);
+        if (isNaN(curVal) || curVal > maxVal || curVal <= 0) {
+            $valueCellGap.val(config.defaultVal);
+            $valueSpanCellGap.html(config.defaultVal);
+        }
     }
 
     // Units
@@ -336,12 +382,15 @@ $(function() {
     }
 
     function setPropertyUnits(val) {
-        if (val == 'in' || val != 'ft')
-            _units = UNITS.Inches;
-        else
+        if (val === 'in' || val === 'ft' || val === 'mm' || val === 'cm') {
+            _units = val;
+        } else {
             _units = UNITS.Centimeters;
+        }
 
         updatePropertyUnitsIndicator();
+        updateCellGapForUnits();
+        setPropertyPagePadding(_padding);
     }
 
     updatePropertyUnitsIndicator();


### PR DESCRIPTION
1 - Padding was calculated by scaling, for non-square profiles resulting in unequal padding between the sides. This change attempts to make padding more even: screenshots before/after below.
2 - Consistently use units set in the document in generator dialog.
3 - Remove temp SVGs
4 - Code cleanup from Claude.

<img width="601" height="340" alt="Screenshot 2026-05-30 230045" src="https://github.com/user-attachments/assets/78e48c7d-f925-4494-a356-d69b4450f8b2" />

<img width="789" height="471" alt="image" src="https://github.com/user-attachments/assets/f7729012-56af-4162-8377-0ab090132e85" />

